### PR TITLE
Fixed the bug in tree_traverse()

### DIFF
--- a/src/tree_common.c
+++ b/src/tree_common.c
@@ -179,7 +179,7 @@ tree_traverse(void* Tree, dict_visit_func visit)
 
     size_t count = 0;
     if (tree->root) {
-	tree_node* node = tree_node_min(tree);
+	tree_node* node = tree_node_min(tree->root);
 	do {
 	    ++count;
 	    if (!visit(node->key, node->datum))


### PR DESCRIPTION
To tree_node_min() function call, 'tree' was
passed as argument instead of 'tree->root'.
