### PR TITLE
Support user specified data for visit callback

### DIFF
--- a/include/dict.h
+++ b/include/dict.h
@@ -56,7 +56,7 @@ typedef int	    (*dict_compare_func)(const void*, const void*);
  * from a dictionary. */
 typedef void	    (*dict_delete_func)(void*, void*);
 /* A pointer to a function used for iterating over dictionary contents. */
-typedef bool	    (*dict_visit_func)(const void*, void*);
+typedef bool	    (*dict_visit_func)(const void*, void*, void*);
 /* A pointer to a function that returns the hash value of a key. */
 typedef unsigned    (*dict_hash_func)(const void*);
 /* A pointer to a function that returns the priority of a key. */
@@ -89,7 +89,7 @@ typedef void**      (*dict_search_func)(void* obj, const void* key);
 typedef dict_remove_result
 		    (*dict_remove_func)(void* obj, const void* key);
 typedef size_t      (*dict_clear_func)(void* obj, dict_delete_func delete_func);
-typedef size_t      (*dict_traverse_func)(void* obj, dict_visit_func visit);
+typedef size_t      (*dict_traverse_func)(void* obj, dict_visit_func visit, void* user_data);
 typedef bool	    (*dict_select_func)(void *obj, size_t n, const void** key, void** datum);
 typedef size_t      (*dict_count_func)(const void* obj);
 typedef bool	    (*dict_verify_func)(const void* obj);
@@ -163,7 +163,7 @@ typedef struct {
 #define dict_search_gt(dct,key)	    ((dct)->_vtable->search_gt ? (dct)->_vtable->search_gt((dct)->_object, (key)) : NULL)
 #define dict_remove(dct,key)	    ((dct)->_vtable->remove((dct)->_object, (key)))
 #define dict_clear(dct,func)	    ((dct)->_vtable->clear((dct)->_object, (func)))
-#define dict_traverse(dct,func)	    ((dct)->_vtable->traverse((dct)->_object, (func)))
+#define dict_traverse(dct,func,user_data)	    ((dct)->_vtable->traverse((dct)->_object, (func), (user_data)))
 #define dict_select(dct,n,key,d)    ((dct)->_vtable->select && (dct)->_vtable->select((dct)->_object, (n), (key), (d)))
 #define dict_count(dct)		    ((dct)->_vtable->count((dct)->_object))
 #define dict_verify(dct)	    ((dct)->_vtable->verify((dct)->_object))

--- a/include/hashtable.h
+++ b/include/hashtable.h
@@ -44,7 +44,7 @@ void**		hashtable_search(hashtable* table, const void* key);
 dict_remove_result
 		hashtable_remove(hashtable* table, const void* key);
 size_t		hashtable_clear(hashtable* table, dict_delete_func delete_func);
-size_t		hashtable_traverse(hashtable* table, dict_visit_func visit);
+size_t		hashtable_traverse(hashtable* table, dict_visit_func visit, void* user_data);
 size_t		hashtable_count(const hashtable* table);
 size_t		hashtable_size(const hashtable* table);
 size_t		hashtable_slots_used(const hashtable* table);

--- a/include/hashtable2.h
+++ b/include/hashtable2.h
@@ -44,7 +44,7 @@ void**		hashtable2_search(hashtable2* table, const void* key);
 dict_remove_result
 		hashtable2_remove(hashtable2* table, const void* key);
 size_t		hashtable2_clear(hashtable2* table, dict_delete_func delete_func);
-size_t		hashtable2_traverse(hashtable2* table, dict_visit_func visit);
+size_t		hashtable2_traverse(hashtable2* table, dict_visit_func visit, void* user_data);
 size_t		hashtable2_count(const hashtable2* table);
 size_t		hashtable2_size(const hashtable2* table);
 size_t		hashtable2_slots_used(const hashtable2* table);

--- a/include/hb_tree.h
+++ b/include/hb_tree.h
@@ -48,8 +48,8 @@ void**		hb_tree_search_gt(hb_tree* tree, const void* key);
 dict_remove_result
 		hb_tree_remove(hb_tree* tree, const void* key);
 size_t		hb_tree_clear(hb_tree* tree, dict_delete_func delete_func);
-size_t		hb_tree_traverse(hb_tree* tree, dict_visit_func visit);
-bool		hb_tree_select(hb_tree* tree, size_t n, const void** key, void** datum);
+size_t		hb_tree_traverse(hb_tree* tree, dict_visit_func visit, void* user_data);
+bool        hb_tree_select(hb_tree* tree, size_t n, const void** key, void** datum);
 size_t		hb_tree_count(const hb_tree* tree);
 size_t		hb_tree_min_path_length(const hb_tree* tree);
 size_t		hb_tree_max_path_length(const hb_tree* tree);

--- a/include/pr_tree.h
+++ b/include/pr_tree.h
@@ -48,8 +48,8 @@ void**		pr_tree_search_gt(pr_tree* tree, const void* key);
 dict_remove_result
 		pr_tree_remove(pr_tree* tree, const void* key);
 size_t		pr_tree_clear(pr_tree* tree, dict_delete_func delete_func);
-size_t		pr_tree_traverse(pr_tree* tree, dict_visit_func visit);
-bool		pr_tree_select(pr_tree* tree, size_t n, const void** key, void** datum);
+size_t		pr_tree_traverse(pr_tree* tree, dict_visit_func visit, void* user_data);
+bool        pr_tree_select(pr_tree* tree, size_t n, const void** key, void** datum);
 size_t		pr_tree_count(const pr_tree* tree);
 size_t		pr_tree_min_path_length(const pr_tree* tree);
 size_t		pr_tree_max_path_length(const pr_tree* tree);

--- a/include/rb_tree.h
+++ b/include/rb_tree.h
@@ -48,8 +48,8 @@ void**		rb_tree_search_gt(rb_tree* tree, const void* key);
 dict_remove_result
 		rb_tree_remove(rb_tree* tree, const void* key);
 size_t		rb_tree_clear(rb_tree* tree, dict_delete_func delete_func);
-size_t		rb_tree_traverse(rb_tree* tree, dict_visit_func visit);
-bool		rb_tree_select(rb_tree* tree, size_t n, const void** key, void** datum);
+size_t		rb_tree_traverse(rb_tree* tree, dict_visit_func visit, void* user_data);
+bool        rb_tree_select(rb_tree* tree, size_t n, const void** key, void** datum);
 size_t		rb_tree_count(const rb_tree* tree);
 size_t		rb_tree_min_path_length(const rb_tree* tree);
 size_t		rb_tree_max_path_length(const rb_tree* tree);

--- a/include/skiplist.h
+++ b/include/skiplist.h
@@ -48,7 +48,7 @@ void**		skiplist_search_gt(skiplist* list, const void* key);
 dict_remove_result
 		skiplist_remove(skiplist* list, const void* key);
 size_t		skiplist_clear(skiplist* list, dict_delete_func delete_func);
-size_t		skiplist_traverse(skiplist* list, dict_visit_func visit);
+size_t		skiplist_traverse(skiplist* list, dict_visit_func visit, void* user_data);
 size_t		skiplist_count(const skiplist* list);
 bool		skiplist_verify(const skiplist* list);
 

--- a/include/sp_tree.h
+++ b/include/sp_tree.h
@@ -48,8 +48,8 @@ void**		sp_tree_search_gt(sp_tree* tree, const void* key);
 dict_remove_result
 		sp_tree_remove(sp_tree* tree, const void* key);
 size_t		sp_tree_clear(sp_tree* tree, dict_delete_func delete_func);
-size_t		sp_tree_traverse(sp_tree* tree, dict_visit_func visit);
-bool		sp_tree_select(sp_tree* tree, size_t n, const void** key, void** datum);
+size_t		sp_tree_traverse(sp_tree* tree, dict_visit_func visit, void* user_data);
+bool        sp_tree_select(sp_tree* tree, size_t n, const void** key, void** datum);
 size_t		sp_tree_count(const sp_tree* tree);
 size_t		sp_tree_min_path_length(const sp_tree* tree);
 size_t		sp_tree_max_path_length(const sp_tree* tree);

--- a/include/tr_tree.h
+++ b/include/tr_tree.h
@@ -48,8 +48,8 @@ void**		tr_tree_search_gt(tr_tree* tree, const void* key);
 dict_remove_result
 		tr_tree_remove(tr_tree* tree, const void* key);
 size_t		tr_tree_clear(tr_tree* tree, dict_delete_func delete_func);
-size_t		tr_tree_traverse(tr_tree* tree, dict_visit_func visit);
-bool		tr_tree_select(tr_tree* tree, size_t n, const void** key, void** datum);
+size_t		tr_tree_traverse(tr_tree* tree, dict_visit_func visit, void* user_data);
+bool        tr_tree_select(tr_tree* tree, size_t n, const void** key, void** datum);
 size_t		tr_tree_count(const tr_tree* tree);
 size_t		tr_tree_min_path_length(const tr_tree* tree);
 size_t		tr_tree_max_path_length(const tr_tree* tree);

--- a/include/wb_tree.h
+++ b/include/wb_tree.h
@@ -48,7 +48,7 @@ void**		wb_tree_search_gt(wb_tree* tree, const void* key);
 dict_remove_result
 		wb_tree_remove(wb_tree* tree, const void* key);
 size_t		wb_tree_clear(wb_tree* tree, dict_delete_func delete_func);
-size_t		wb_tree_traverse(wb_tree* tree, dict_visit_func visit);
+size_t		wb_tree_traverse(wb_tree* tree, dict_visit_func visit, void* user_data);
 bool		wb_tree_select(wb_tree* tree, size_t n, const void** key, void** datum);
 size_t		wb_tree_count(const wb_tree* tree);
 size_t		wb_tree_min_path_length(const wb_tree* tree);

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -260,13 +260,13 @@ hashtable_clear(hashtable* table, dict_delete_func delete_func)
 }
 
 size_t
-hashtable_traverse(hashtable* table, dict_visit_func visit)
+hashtable_traverse(hashtable* table, dict_visit_func visit, void* user_data)
 {
     size_t count = 0;
     for (unsigned i = 0; i < table->size; i++)
 	for (hash_node* node = table->table[i]; node; node = node->next) {
 	    ++count;
-	    if (!visit(node->key, node->datum))
+	    if (!visit(node->key, node->datum, user_data))
 		return count;
 	}
     return count;

--- a/src/hashtable2.c
+++ b/src/hashtable2.c
@@ -314,14 +314,14 @@ hashtable2_clear(hashtable2* table, dict_delete_func delete_func)
 }
 
 size_t
-hashtable2_traverse(hashtable2* table, dict_visit_func visit)
+hashtable2_traverse(hashtable2* table, dict_visit_func visit, void* user_data)
 {
     size_t count = 0;
     hash_node *node = table->table;
     for (hash_node *const end = table->table + table->size; node != end; ++node) {
 	if (node->hash) {
 	    ++count;
-	    if (!visit(node->key, node->datum))
+	    if (!visit(node->key, node->datum, user_data))
 		break;
 	}
     }

--- a/src/hb_tree.c
+++ b/src/hb_tree.c
@@ -419,7 +419,11 @@ hb_tree_remove(hb_tree* tree, const void* key)
     return result;
 }
 
-size_t hb_tree_traverse(hb_tree* tree, dict_visit_func visit) { return tree_traverse(tree, visit); }
+size_t
+hb_tree_traverse(hb_tree* tree, dict_visit_func visit, void* user_data)
+{
+    return tree_traverse(tree, visit, user_data);
+}
 
 bool
 hb_tree_select(hb_tree *tree, size_t n, const void **key, void **datum)

--- a/src/pr_tree.c
+++ b/src/pr_tree.c
@@ -330,7 +330,12 @@ pr_tree_remove(pr_tree* tree, const void* key)
 }
 
 size_t pr_tree_clear(pr_tree* tree, dict_delete_func delete_func) { return tree_clear(tree, delete_func); }
-size_t pr_tree_traverse(pr_tree* tree, dict_visit_func visit) { return tree_traverse(tree, visit); }
+
+size_t
+pr_tree_traverse(pr_tree* tree, dict_visit_func visit, void* user_data)
+{
+    return tree_traverse(tree, visit, user_data);
+}
 
 bool
 pr_tree_select(pr_tree* tree, size_t n, const void** key, void** datum)

--- a/src/rb_tree.c
+++ b/src/rb_tree.c
@@ -350,7 +350,7 @@ size_t rb_tree_max_path_length(const rb_tree* tree) { return tree_max_path_lengt
 size_t rb_tree_total_path_length(const rb_tree* tree) { return tree_total_path_length(tree); }
 
 size_t
-rb_tree_traverse(rb_tree* tree, dict_visit_func visit)
+rb_tree_traverse(rb_tree* tree, dict_visit_func visit, void* user_data)
 {
     if (tree->root == NULL)
 	return 0;
@@ -359,7 +359,7 @@ rb_tree_traverse(rb_tree* tree, dict_visit_func visit)
     rb_node* node = tree_node_min(tree->root);
     for (; node != NULL; node = node_next(node)) {
 	++count;
-	if (!visit(node->key, node->datum))
+	if (!visit(node->key, node->datum, user_data))
 	    break;
     }
     return count;

--- a/src/skiplist.c
+++ b/src/skiplist.c
@@ -427,12 +427,12 @@ skiplist_clear(skiplist* list, dict_delete_func delete_func)
 }
 
 size_t
-skiplist_traverse(skiplist* list, dict_visit_func visit)
+skiplist_traverse(skiplist* list, dict_visit_func visit, void* user_data)
 {
     size_t count = 0;
     for (skip_node* node = list->head->link[0]; node; node = node->link[0]) {
 	++count;
-	if (!visit(node->key, node->datum))
+	if (!visit(node->key, node->datum, user_data))
 	    break;
     }
     return count;

--- a/src/sp_tree.c
+++ b/src/sp_tree.c
@@ -375,7 +375,7 @@ sp_tree_remove(sp_tree* tree, const void* key)
     return result;
 }
 
-size_t sp_tree_traverse(sp_tree* tree, dict_visit_func visit) { return tree_traverse(tree, visit); }
+size_t sp_tree_traverse(sp_tree* tree, dict_visit_func visit, void* user_data) { return tree_traverse(tree, visit, user_data); }
 bool sp_tree_select(sp_tree* tree, size_t n, const void** key, void** datum) { return tree_select(tree, n, key, datum); }
 size_t sp_tree_count(const sp_tree* tree) { return tree_count(tree); }
 size_t sp_tree_min_path_length(const sp_tree* tree) { return tree_min_path_length(tree); }

--- a/src/tr_tree.c
+++ b/src/tr_tree.c
@@ -215,7 +215,7 @@ void** tr_tree_search_le(tr_tree* tree, const void* key) { return tree_search_le
 void** tr_tree_search_lt(tr_tree* tree, const void* key) { return tree_search_lt(tree, key); }
 void** tr_tree_search_ge(tr_tree* tree, const void* key) { return tree_search_ge(tree, key); }
 void** tr_tree_search_gt(tr_tree* tree, const void* key) { return tree_search_gt(tree, key); }
-size_t tr_tree_traverse(tr_tree* tree, dict_visit_func visit) { return tree_traverse(tree, visit); }
+size_t tr_tree_traverse(tr_tree* tree, dict_visit_func visit, void* user_data) { return tree_traverse(tree, visit, user_data); }
 bool tr_tree_select(tr_tree* tree, size_t n, const void** key, void** datum) { return tree_select(tree, n, key, datum); }
 size_t tr_tree_count(const tr_tree* tree) { return tree_count(tree); }
 size_t tr_tree_min_path_length(const tr_tree* tree) { return tree_min_path_length(tree); }

--- a/src/tree_common.c
+++ b/src/tree_common.c
@@ -249,7 +249,7 @@ tree_search_gt(void* Tree, const void* key)
 }
 
 size_t
-tree_traverse(void* Tree, dict_visit_func visit)
+tree_traverse(void* Tree, dict_visit_func visit, void* user_data)
 {
     ASSERT(visit != NULL);
 
@@ -259,7 +259,7 @@ tree_traverse(void* Tree, dict_visit_func visit)
 	tree_node* node = tree_node_min(t->root);
 	do {
 	    ++count;
-	    if (!visit(node->key, node->datum))
+	    if (!visit(node->key, node->datum, user_data))
 		break;
 	    node = tree_node_next(node);
 	} while (node);

--- a/src/tree_common.h
+++ b/src/tree_common.h
@@ -96,7 +96,7 @@ void*	    tree_search_gt_node(void *tree, const void *key);
 /* Traverses the tree in order, calling |visit| with each key and value pair,
  * stopping if |visit| returns false. Returns the number of times |visit| was
  * called. */
-size_t	    tree_traverse(void *tree, dict_visit_func visit);
+size_t	    tree_traverse(void *tree, dict_visit_func visit, void* user_data);
 /* Put the key and datum of the |n|th element of |tree| into |key| and |datum|
  * and return true, or, if n is greater than or equal to the number of elements,
  * return false. */

--- a/src/wb_tree.c
+++ b/src/wb_tree.c
@@ -323,7 +323,7 @@ wb_tree_remove(wb_tree* tree, const void* key)
 }
 
 size_t wb_tree_clear(wb_tree* tree, dict_delete_func delete_func) { return tree_clear(tree, delete_func); }
-size_t wb_tree_traverse(wb_tree* tree, dict_visit_func visit) { return tree_traverse(tree, visit); }
+size_t wb_tree_traverse(wb_tree* tree, dict_visit_func visit, void* user_data) { return tree_traverse(tree, visit, user_data); }
 
 bool
 wb_tree_select(wb_tree* tree, size_t n, const void** key, void** datum)


### PR DESCRIPTION
Adding data pointer to the visit callback allows the user to set and use state without resorting to globally maintained state