### PR TITLE
Make libdict using cmake

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: None

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 2.8)
+set(_ECLIPSE_VERSION 4.5)
+project(libdict)
+
+enable_language(C)
+add_definitions(-std=c11)
+
+set(LIBDICT_SOURCES
+    src/dict.c
+    src/hashtable.c
+    src/hashtable2.c
+    src/hashtable_common.c
+    src/hb_tree.c
+    src/pr_tree.c
+    src/rb_tree.c
+    src/skiplist.c
+    src/sp_tree.c
+    src/tr_tree.c
+    src/tree_common.c
+    src/wb_tree.c
+)
+
+include_directories(include)
+include_directories(src)
+
+add_library(dict STATIC ${LIBDICT_SOURCES})
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" )
+    set_target_properties(dict PROPERTIES COMPILE_FLAGS "-fPIC")
+endif(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" )
+set_target_properties(dict PROPERTIES PREFIX "lib")
+
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}")
+find_package(CUnit REQUIRED)
+enable_testing()
+add_executable(dict_test unit_tests.c)
+target_include_directories(dict_test PRIVATE ${CUNIT_INCLUDE_DIRS})
+target_link_libraries (dict_test dict)
+target_link_libraries(dict_test ${CUNIT_LIBRARIES})
+
+add_test(
+    NAME dict_test
+    COMMAND dict_test
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+

--- a/FindCUnit.cmake
+++ b/FindCUnit.cmake
@@ -1,0 +1,19 @@
+# CUNIT_INCLUDE_DIRS - where to find <CUnit/CUnit.h>, etc.
+# CUNIT_LIBRARIES - List of libraries when using libcunit.
+# CUNIT_FOUND - True if libcunit found.
+if(CUNIT_INCLUDE_DIRS)
+	# Already in cache, be silent
+	set(CUNIT_FIND_QUIETLY YES)
+endif()
+
+find_path(CUNIT_INCLUDE_DIRS CUnit/CUnit.h)
+find_library(CUNIT_LIBRARY NAMES cunit libcunit)
+
+# handle the QUIETLY and REQUIRED arguments and set CUNIT_FOUND to TRUE if
+# all listed variables are TRUE
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(CUNIT DEFAULT_MSG CUNIT_LIBRARY CUNIT_INCLUDE_DIRS)
+
+if(CUNIT_FOUND)
+	set(CUNIT_LIBRARIES ${CUNIT_LIBRARY})
+endif()


### PR DESCRIPTION
 - Cmake support for libdict binaries
 - fpic: Make re-locatable libraries in linux
 - ignore clang format
 - Add unit-tests
 - find CUnit in a portable way